### PR TITLE
Updated layer name conversion for resistance to capitalization changes

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+Run unit testing from the outermost `deeplift` directory with:
+```
+% PYTHONPATH=. pytest
+```


### PR DESCRIPTION
- new behavior for layer name conversion is to compare lowercased names
- changed `activation_to_conversion_function` from a dict to an actual function to maintain consistency w/ changes
- added a short README.md in the`tests` folder explaining how to run tests w/o installing DeepLIFT