### PR TITLE
Concat layer pos and neg contribs calculation fix

### DIFF
--- a/deeplift.egg-info/PKG-INFO
+++ b/deeplift.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: deeplift
-Version: 0.5.1-theano
+Version: 0.5.2-theano
 Summary: Interpretable deep learning
 Home-page: NA
 Author: UNKNOWN

--- a/deeplift/blobs/core.py
+++ b/deeplift/blobs/core.py
@@ -786,8 +786,9 @@ class Concat(OneDimOutputMixin, Merge):
         return B.concat(tensor_list=input_act_vars, axis=self.axis)
 
     def _build_pos_and_neg_contribs(self):
-        inp_pos_contribs, inp_neg_contribs =\
-            self._get_input_pos_and_neg_contribs()
+        inp_pos_and_neg_contribs = self._get_input_pos_and_neg_contribs()
+        inp_pos_contribs = [x[0] for x in inp_pos_and_neg_contribs]
+        inp_neg_contribs = [x[1] for x in inp_pos_and_neg_contribs]
         pos_contribs = self._build_activation_vars(inp_pos_contribs) 
         neg_contribs = self._build_activation_vars(inp_neg_contribs)
         return pos_contribs, neg_contribs

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__== '__main__':
           description='Interpretable deep learning',
           url='NA',
           download_url='NA',
-          version='0.5.1-theano',
+          version='0.5.2-theano',
           packages=['deeplift', 'deeplift.backend',
                     'deeplift.blobs', 'deeplift.visualization',
                     'deeplift.conversion'],


### PR DESCRIPTION
Unit test for merge layer happened to have both layers of the same dimensions, and so missed this issue (also I don't think theano throws an error unless you are specifically calculating contributions w.r.t. the merge layer, and the bug doesn't affect any results unless the merge layer is immediately followed by a nonlinearity, since it basically just messed up the positive/negative split at the merge layer which is only relevant when the layer is followed by a nonlinearity)