### PR TITLE
DeepLIFT_Genomics mode handles NoOp layers

### DIFF
--- a/deeplift/blobs/activations.py
+++ b/deeplift/blobs/activations.py
@@ -52,7 +52,8 @@ class Activation(SingleInputMixin, OneDimOutputMixin, Node):
         if (self.nonlinear_mxts_mode==
              NonlinearMxtsMode.DeepLIFT_GenomicsDefault):
             preceding_linear_layer = self.get_inputs()
-            if (type(preceding_linear_layer).__name__=="BatchNormalization"):
+            while (type(preceding_linear_layer).__name__ in [
+                   "BatchNormalization", "NoOp"]):
                 preceding_linear_layer = preceding_linear_layer.get_inputs()
             if (self.verbose):
                 print("For layer "+str(self.get_name())+" the preceding linear"

--- a/tests/blobs/test_deeplift_genomics_default_mode.py
+++ b/tests/blobs/test_deeplift_genomics_default_mode.py
@@ -31,7 +31,7 @@ class TestDense(unittest.TestCase):
         self.assertEqual(relu_after_dense.nonlinear_mxts_mode,
                          NonlinearMxtsMode.RevealCancel)
 
-    def test_relu_after_dense_batchnorm(self): 
+    def test_relu_after_dense_batchnorm_noop_noop(self): 
         input_layer = blobs.Input(num_dims=None,
                                   shape=(None,4))
         dense_layer = blobs.Dense(W=np.random.random((4,2)),
@@ -43,9 +43,13 @@ class TestDense(unittest.TestCase):
                         axis=-1, mean=np.array([-0.5, 0.5]),
                         std=np.array([1.0, 1.0]), epsilon=0.001)
         batch_norm.set_inputs(dense_layer)
+        noop_layer1 = blobs.NoOp()
+        noop_layer1.set_inputs(batch_norm)
+        noop_layer2 = blobs.NoOp()
+        noop_layer2.set_inputs(noop_layer1)
         relu_after_bn = blobs.ReLU(nonlinear_mxts_mode=
                                    NonlinearMxtsMode.DeepLIFT_GenomicsDefault) 
-        relu_after_bn.set_inputs(batch_norm)
+        relu_after_bn.set_inputs(noop_layer2)
         relu_after_bn.build_fwd_pass_vars()
         self.assertEqual(relu_after_bn.nonlinear_mxts_mode,
                          NonlinearMxtsMode.RevealCancel)


### PR DESCRIPTION
The DeepLIFT_Genomics mode is adaptive based on the previous layer (Rescale for Convolutional layers, RevealCancel for Dense layers). NoOp layers correspond to dropout layers; this fix just looks for the layer preceding the NoOp layer to determine what to set the multiplier mode to (similar to the handling of BatchNorm layers).