### PR TITLE
Permute layer for tensorflow backend

### DIFF
--- a/deeplift/blobs/core.py
+++ b/deeplift/blobs/core.py
@@ -733,6 +733,38 @@ class BatchNormalization(SingleInputMixin, Node):
         return pos_mxts_increments, neg_mxts_increments
 
 
+class Permute(SingleInputMixin, Node):
+
+        def __init__(self,  **kwargs):
+            super(Permute, self).__init__(**kwargs)
+
+        def _compute_shape(self, input_shape):
+            myorder=[0, 2, 1]
+            output_shape = [input_shape[i] for i in myorder]
+            return output_shape
+
+        def _build_activation_vars(self, input_act_vars):
+            to_return = tf.transpose(input_act_vars, perm = [0,2,1])
+            return to_return
+
+        def _check_inputs(self):
+            pass
+
+        def _build_pos_and_neg_contribs(self):
+            ( inp_pos_contribs,
+              inp_neg_contribs ) = self._get_input_pos_and_neg_contribs()
+            pos_contribs = self._build_activation_vars(inp_pos_contribs)
+            neg_contribs = self._build_activation_vars(inp_neg_contribs)
+            return pos_contribs, neg_contribs
+
+        def _get_mxts_increments_for_inputs(self):
+            pos_mxts = self.get_pos_mxts()
+            neg_mxts = self.get_neg_mxts()
+            pos_mxts = tf.transpose(pos_mxts, perm=[0, 2, 1])
+            neg_mxts = tf.transpose(neg_mxts, perm=[0, 2, 1])
+            return pos_mxts, neg_mxts
+
+
 class Merge(ListInputMixin, Node):
 
     def __init__(self, axis, **kwargs):

--- a/deeplift/conversion/keras_conversion.py
+++ b/deeplift/conversion/keras_conversion.py
@@ -46,6 +46,10 @@ def batchnorm_conversion(layer, name, verbose, **kwargs):
     )] 
 
 
+def permute_conversion(layer, name, verbose, **kwargs):
+    return [blobs.Permute(name=name)]
+
+
 def conv1d_conversion(layer, name, verbose,
                       nonlinear_mxts_mode, conv_mxts_mode, **kwargs):
     #nonlinear_mxts_mode only used for activation
@@ -239,6 +243,7 @@ def activation_to_conversion_function(activation):
 
 def layer_name_to_conversion_function(layer_name):
     name_dict = {
+        'permute': permute_conversion,
         'convolution1d': conv1d_conversion,
         'maxpooling1d': maxpool1d_conversion,
         'averagepooling1d': avgpool1d_conversion,


### PR DESCRIPTION
This PR adds support for the Permute layer for models with tensorflow backend.