### PR TITLE
Added function for computing hypothetical contributions

### DIFF
--- a/deeplift.egg-info/PKG-INFO
+++ b/deeplift.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: deeplift
-Version: 0.5.3-theano
+Version: 0.5.4-theano
 Summary: Interpretable deep learning
 Home-page: NA
 Author: UNKNOWN

--- a/deeplift/util.py
+++ b/deeplift/util.py
@@ -379,6 +379,28 @@ def get_top_n_scores_per_region(
         return np.array(top_n_scores), np.array(top_n_indices)
 
 
+def get_hypothetical_contribs_func(multipliers_function):
+
+    def hypothetical_contribs_func(task_idx,
+                                  input_data_list,
+                                  input_references_list,
+                                  hypothetical_input_data_list,
+                                  batch_size,
+                                  progress_update):
+        multipliers = multipliers_function(
+                            task_idx=task_idx,
+                            input_data_list=input_data_list,
+                            input_references_list=input_references_list, 
+                            batch_size=batch_size,
+                            progress_update=progress_update)
+        differences_from_reference =(
+            np.array(hypothetical_input_data_list)
+            -np.array(input_references_list))
+        hypothetical_contribs = differences_from_reference*multipliers
+        return hypothetical_contribs
+    return hypothetical_contribs_func
+
+
 def get_integrated_gradients_function(gradient_computation_function, 
                                       num_intervals, right_rectangle=False):
     def compute_integrated_gradients(

--- a/deeplift/util.py
+++ b/deeplift/util.py
@@ -379,25 +379,32 @@ def get_top_n_scores_per_region(
         return np.array(top_n_scores), np.array(top_n_indices)
 
 
-def get_hypothetical_contribs_func(multipliers_function):
-
+def get_hypothetical_contribs_func_genomics(multipliers_function):
     def hypothetical_contribs_func(task_idx,
                                   input_data_list,
                                   input_references_list,
-                                  hypothetical_input_data_list,
                                   batch_size,
                                   progress_update):
+        assert len(input_data_list)==1
+        assert len(input_references_list)==1
+        assert len(input_data_list[0].shape)==3, input_data_list[0].shape
+        assert len(input_data_list[0].shape)==3, input_data_list[0].shape
         multipliers = multipliers_function(
                             task_idx=task_idx,
                             input_data_list=input_data_list,
                             input_references_list=input_references_list, 
                             batch_size=batch_size,
                             progress_update=progress_update)
-        differences_from_reference =(
-            np.array(hypothetical_input_data_list)
-            -np.array(input_references_list))
-        hypothetical_contribs = differences_from_reference*multipliers
-        return hypothetical_contribs
+        to_return = np.zeros_like(input_data_list[0]).astype("float")
+        for i in range(input_data_list[0].shape[-1]):
+            hypothetical_input = np.zeros_like(input_data_list[0])\
+                                   .astype("float")
+            hypothetical_input[:,:,i] = 1.0
+            difference_from_reference =\
+                (hypothetical_input-np.array(input_references_list[0]))
+            hypothetical_contribs = difference_from_reference*multipliers
+            to_return[:,:,i] = np.sum(hypothetical_contribs,axis=-1)
+        return to_return
     return hypothetical_contribs_func
 
 

--- a/deeplift/util.py
+++ b/deeplift/util.py
@@ -381,13 +381,13 @@ def get_top_n_scores_per_region(
 
 def get_hypothetical_contribs_func_onehot(multipliers_function):
     """
-        Meant for models with one-hot encoded genomic sequence input.
+        Meant for models with one-hot encoded sequence input.
         Inputs:
             multipliers_function: a function (usually produced by
                 model.get_target_multipliers_func) that takes task_idx,
                 input_data_list, input_references_list, batch_size
                 and progress_update as inputs and returns the multipliers
-                on one-hot encoded genomic sequence input. The first
+                on one-hot encoded sequence input. The first
                 entry of input_data_list is assumed to be a 3-dimensional
                 array where the first dimension is the example index,
                 the second dimension is length and the
@@ -398,8 +398,8 @@ def get_hypothetical_contribs_func_onehot(multipliers_function):
                 be for each of the one-hot encoding possibilities.
                 The calculation is as follows: At each
                 position, we iterate over the one-hot encoding
-                possibilities (for genomic sequence, this is ACGT)
-                and compute the hypothetical 
+                possibilities (eg: for genomic sequence, this is ACGT i.e.
+                1000, 0100, 0010 and 0001) and compute the hypothetical 
                 difference-from-reference in each case.
                 We then multiply the hypothetical
                 differences-from-reference with the

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__== '__main__':
           description='Interpretable deep learning',
           url='NA',
           download_url='NA',
-          version='0.5.3-theano',
+          version='0.5.4-theano',
           packages=['deeplift', 'deeplift.backend',
                     'deeplift.blobs', 'deeplift.visualization',
                     'deeplift.conversion'],


### PR DESCRIPTION
The original version of MoDISco, developed back when we were using grad*input, had a step where the grad*input scores were replaced with just the gradients because the gradients behaved like an "autocomplete" of motifs (i.e. they gave you a sense of what the hypothetical contributions would be if various changes were made to the bases; note that sometimes you can skip this step and still get decent results, but I generally find it improves the clustering). Due to the redundancy in one-hot encodings (i.e. if you know 3/4th of the values along the channel axis, you know the 4th value) it was necessary to mean-normalize the gradients across the channel axis* (in practice, this was accomplished by mean-normalizing the weights of the first convolutional layer). When we moved to the difference-from-reference formulation of DeepLIFT, I recommended that people use the multipliers instead of the gradients for this MoDISco step due to the analogy between multipliers and gradients. The catch is that interpreting mean-normalized multipliers as "hypothetical contributions" implicitly assumes an all-zero reference. To fix this, I wrote the method `get_hypothetical_contribs_func_onehot(multipliers_function)` in `util.py`; it takes as input a function for computing the multipliers and returns a function that estimates the hypothetical contributions according to whatever reference is supplied. Comments on how it works are provided in the docstring, and are reproduced below:

```
def get_hypothetical_contribs_func_onehot(multipliers_function):
    """
        Meant for models with one-hot encoded sequence input.
        Inputs:
            multipliers_function: a function (usually produced by
                model.get_target_multipliers_func) that takes task_idx,
                input_data_list, input_references_list, batch_size
                and progress_update as inputs and returns the multipliers
                on one-hot encoded sequence input. The first
                entry of input_data_list is assumed to be a 3-dimensional
                array where the first dimension is the example index,
                the second dimension is length and the
                last dimension is the one-hot encoded channel axis.
        Returns:
            a function that takes the same arguments as multipliers_func
                and returns an estimate of what the contributions would
                be for each of the one-hot encoding possibilities.
                The calculation is as follows: At each
                position, we iterate over the one-hot encoding
                possibilities (eg: for genomic sequence, this is ACGT i.e.
                1000, 0100, 0010 and 0001) and compute the hypothetical 
                difference-from-reference in each case.
                We then multiply the hypothetical
                differences-from-reference with the
                multipliers to get the hypothetical contributions. 
                For each of the one-hot encoding possibilities,
                the hypothetical contributions are summed across the
                channel axis to estimate the total hypothetical
                contribution at each position.
                The reason this is only an estimate
                is that the multipliers were computed
                using the actual input and not the hypothetical inputs.
    """
```

*to understand why, think about how a high positive weight on all 4 one-hot encoding possibilities essentially means the position is doubling up as a positive bias term, since at least one of the positions is guaranteed to be a 1