### PR TITLE
Added support for multiple (constant) modes in shuffle seq reference function

### DIFF
--- a/deeplift.egg-info/PKG-INFO
+++ b/deeplift.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: deeplift
-Version: 0.5.4-theano
+Version: 0.5.5-theano
 Summary: Interpretable deep learning
 Home-page: NA
 Author: UNKNOWN

--- a/deeplift/__init__.py
+++ b/deeplift/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.4.0'
+__version__ = '0.5.5-theano'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__== '__main__':
           description='Interpretable deep learning',
           url='NA',
           download_url='NA',
-          version='0.5.4-theano',
+          version='0.5.5-theano',
           packages=['deeplift', 'deeplift.backend',
                     'deeplift.blobs', 'deeplift.visualization',
                     'deeplift.conversion'],


### PR DESCRIPTION
Motivated by interpreting models that had both sequence and DNAse inputs, this pull modifies get_shuffle_seq_ref_function to allow the user to pass in the values for the other modes. Only the sequence mode (assumed to be the first mode) is shuffled. This does not break the existing API. 

Usage:

```
shuffle_seq_ref_func = deeplift.util.get_shuffle_seq_ref_function(
    score_computation_function=deeplift_func,
    shuffle_func=deeplift.dinuc_shuffle.dinuc_shuffle,
    one_hot_func=my_func_to_do_one_hot_encoding_from_sequence,
)

deeplift_scores = shuffle_seq_ref_func(
                    task_idx=0,
                    input_data_sequences=fasta_sequence_data,
                    num_refs_per_seq=10,
                    batch_size=50,
                    other_modes_data=[dnase_data])
```

Example at: https://github.com/kundajelab/misc_figures/commit/11fbbeb05f7640fab9589546210022965a10e22b (this is not a public repository; ping me if you want access but don't have it)